### PR TITLE
:see_no_evil: ignore debug log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 .env.*.local
 
 # Log files
+debug.log*
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
![nasty debug log](https://user-images.githubusercontent.com/20266711/48077213-846d7780-e1ef-11e8-9f60-73885530cafd.png)

_Surprise! A random `debug.log` has appeared!_

debug.log should be in gitignore. My preference would be using a wildcard (`*.log`) instead of listing each type of log individually, but I was following your gitignore style.